### PR TITLE
polynom.c (make_cast()) caused segmentation fault

### DIFF
--- a/source_c/polynom.c
+++ b/source_c/polynom.c
@@ -228,7 +228,6 @@ void make_cast(FILE *fcast)
       series[j]=series[j+1];
     series[hi]=casted;
   }
-  fclose(fcast);
 }
 
 int main(int argc,char **argv)


### PR DESCRIPTION
fclose() at the end of make_cast  (along with the fclose at the end of main()) caused a segmentation fault.