### PR TITLE
mutual.c caused segmentation fault

### DIFF
--- a/source_c/mutual.c
+++ b/source_c/mutual.c
@@ -98,10 +98,11 @@ double make_cond_entropy(long t)
   if (t < 0) {
     start=0;
     stop=length+t;
+    t=-t;
   }
   else {
     start=t;
-    stop=length;
+    stop=length-t;
   }
 
   for (i=start;i<stop;i++) {


### PR DESCRIPTION
In line 110 (old line 109) `i+t` would go out of bounds. When `t<0` then `i+t < 0` (for `i=0`) and when `t>0` then `t+i > length`. This caused the segmentation fault.

I would appreciate a second look to ensure my updates go back to what the author originally intended.